### PR TITLE
allow multiple EHRs to be accessed at the same time

### DIFF
--- a/ehrdao/src/main/java/com/ethercis/dao/access/jooq/EhrAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/jooq/EhrAccess.java
@@ -62,9 +62,9 @@ import static com.ethercis.jooq.pg.Tables.*;
 public class EhrAccess extends DataAccess implements  I_EhrAccess {
 
     private static final Logger log = LogManager.getLogger(EhrAccess.class);
-    private static EhrRecord ehrRecord;
+    private EhrRecord ehrRecord;
     private StatusRecord statusRecord = null;
-    private static boolean isNew = false;
+    private boolean isNew = false;
 
     //holds the non serialized archetyped other_details structure
     private Locatable otherDetails = null;
@@ -578,7 +578,7 @@ public class EhrAccess extends DataAccess implements  I_EhrAccess {
 
         ehrAccess.ehrRecord = (EhrRecord)record;
         //retrieveInstanceByNamedSubject the corresponding status
-        ehrAccess.statusRecord = context.fetchOne(STATUS, STATUS.EHR_ID.eq(ehrRecord.getId()));
+        ehrAccess.statusRecord = context.fetchOne(STATUS, STATUS.EHR_ID.eq(ehrAccess.ehrRecord.getId()));
 
         //rebuild otherDetails
         if (ehrAccess.statusRecord.getOtherDetails() != null){
@@ -615,9 +615,9 @@ public class EhrAccess extends DataAccess implements  I_EhrAccess {
         ehrAccess.isNew = false;
 
         //retrieve the current contribution for this ehr
-        ContributionRecord contributionRecord = context.fetchOne(CONTRIBUTION, CONTRIBUTION.EHR_ID.eq(ehrRecord.getId()).and(CONTRIBUTION.CONTRIBUTION_TYPE.eq(ContributionDataType.ehr)));
+        ContributionRecord contributionRecord = context.fetchOne(CONTRIBUTION, CONTRIBUTION.EHR_ID.eq(ehrAccess.ehrRecord.getId()).and(CONTRIBUTION.CONTRIBUTION_TYPE.eq(ContributionDataType.ehr)));
         if (contributionRecord == null)
-            throw new IllegalArgumentException("DB inconsistency: could not find a related contribution for ehr="+ehrRecord.getId());
+            throw new IllegalArgumentException("DB inconsistency: could not find a related contribution for ehr="+ehrAccess.ehrRecord.getId());
 
         UUID contributionId = contributionRecord.getId();
 


### PR DESCRIPTION
Without this fix retrieving two EHRs at the same time will have all instances use the data of the last retrieved EHR without warning.

Test:
```
final I_EhrAccess ehr1 = I_EhrAccess.retrieveInstance(dataAccess, ehrId1);
final I_EhrAccess ehr2 = I_EhrAccess.retrieveInstance(dataAccess, ehrId2);

// this will fail without this fix
assertNotEquals(ehr1.getId(), ehr2.getId());
```