### PR TITLE
use the same groupId as used by the openEHR java-libs

### DIFF
--- a/3rdparty/build.gradle
+++ b/3rdparty/build.gradle
@@ -5,14 +5,14 @@ apply plugin: 'maven-publish'
 publishing {
     publications {
         adl(MavenPublication) {
-            groupId 'ethercis'
+            groupId 'openehr'
             artifactId 'adl-parser'
             version '1.0.9'
 
             artifact 'adl-parser-1.0.9.jar'
         }
         oet(MavenPublication) {
-            groupId 'ethercis'
+            groupId 'openehr'
             artifactId 'oet-parser'
             version '1.0.5'
 
@@ -40,7 +40,7 @@ publishing {
             artifact 'openehr-am-rm-term-1.0.9.jar'
         }
         rmb(MavenPublication) {
-            groupId 'ethercis'
+            groupId 'openehr'
             artifactId 'rm-builder'
             version '1.0.9'
 
@@ -54,7 +54,7 @@ publishing {
             artifact 'thinkehr-framework-jsonlib-2.3.0-JL32.jar'
         }
         xml(MavenPublication) {
-            groupId 'ethercis'
+            groupId 'openehr'
             artifactId 'xml-serializer'
             version '1.0.9'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,12 +4,12 @@ dependencies {
     // *** 3rd party dependencies ***
     compile "ethercis:thinkehr-framework-jsonlib:2.3.0-JL32"
     compile "ethercis:openehr-am-rm-term:1.0.9"
-    compile "ethercis:oet-parser:1.0.5"
+    compile "openehr:oet-parser:1.0.5"
     compile "ethercis:openEHR.v1.OperationalTemplate:1.0.1"
     compile "ethercis:openEHR.v1.Template:1.0.1"
-    compile "ethercis:xml-serializer:1.0.9"
-    compile "ethercis:rm-builder:1.0.9"
-    compile "ethercis:adl-parser:1.0.9"
+    compile "openehr:xml-serializer:1.0.9"
+    compile "openehr:rm-builder:1.0.9"
+    compile "openehr:adl-parser:1.0.9"
 
     // *** project dependencies **
     compile project(':ecis-knowledge-cache')

--- a/knowledge-cache/build.gradle
+++ b/knowledge-cache/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':ecis-validation')
 
     // *** openehr dependencies from the 3rdparty directory ***
-    compile "ethercis:adl-parser:1.0.9"
+    compile "openehr:adl-parser:1.0.9"
     compile "ethercis:openEHR.v1.Template:1.0.1"
 
     // *** test dependencies ***


### PR DESCRIPTION
When using ehrservice with our product we must use a newer version of the adl-parser (1.0.14-ec1 from https://github.com/medrecord/java-libs) than used by ethercis (1.0.9) 
The 1.0.9 version can not parse ADL files generated by the current modelling tools.

By using the same group ID, the latest version is automatically used if available.
