### PR TITLE
Changing the way we close database connections

### DIFF
--- a/ehrdao/src/main/java/com/ethercis/dao/access/interfaces/I_DomainAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/interfaces/I_DomainAccess.java
@@ -83,6 +83,11 @@ public interface I_DomainAccess {
     Connection getConnection();
 
     /**
+     * have JOOQ release the DB connection
+     */
+    void releaseConnection(Connection connection);
+
+    /**
      * get the jOOQ DSL context to perform DB queries
      * @return DSLContext
      * @see org.jooq.DSLContext

--- a/ehrdao/src/main/java/com/ethercis/dao/access/jooq/CompositionAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/jooq/CompositionAccess.java
@@ -546,7 +546,7 @@ public class CompositionAccess extends DataAccess implements I_CompositionAccess
 
         }
 
-//        connection.close();
+        domainAccess.releaseConnection(connection);
 
         return compositionHistoryAccess;
     }

--- a/ehrdao/src/main/java/com/ethercis/dao/access/jooq/ContextAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/jooq/ContextAccess.java
@@ -231,7 +231,7 @@ public class ContextAccess extends DataAccess implements I_ContextAccess {
             );
         }
 
-        connection.close();
+        releaseConnection(connection);
 
         if (uuid != null)
             return uuid;
@@ -341,7 +341,7 @@ public class ContextAccess extends DataAccess implements I_ContextAccess {
 
         Boolean result = updateStatement.execute();
 
-        connection.close();
+        releaseConnection(connection);
 
         return result;
 //        return eventContextRecord.update() > 0;

--- a/ehrdao/src/main/java/com/ethercis/dao/access/jooq/EhrAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/jooq/EhrAccess.java
@@ -234,7 +234,7 @@ public class EhrAccess extends DataAccess implements  I_EhrAccess {
                 retval = resultSet.getString(1);
             }
 
-            connection.close();
+            releaseConnection(connection);
 
             if (retval == null)
                 throw new IllegalArgumentException("Could not store Ehr Status");
@@ -338,7 +338,7 @@ public class EhrAccess extends DataAccess implements  I_EhrAccess {
 //            result |= statusRecord.update() > 0;
             result |= updateStatement.execute();
 
-            connection.close();
+            releaseConnection(connection);
         }
 
         if (force || ehrRecord.changed()){

--- a/ehrdao/src/main/java/com/ethercis/dao/access/jooq/EntryAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/jooq/EntryAccess.java
@@ -506,7 +506,7 @@ public class EntryAccess extends DataAccess implements I_EntryAccess {
 
         Boolean result =  updateStatement.execute();
 
-        connection.close();
+        releaseConnection(connection);
 
         return result;
     }

--- a/ehrdao/src/main/java/com/ethercis/dao/access/support/DataAccess.java
+++ b/ehrdao/src/main/java/com/ethercis/dao/access/support/DataAccess.java
@@ -494,6 +494,11 @@ public abstract class DataAccess implements I_DomainAccess {
     }
 
     @Override
+    public void releaseConnection(Connection connection) {
+        context.configuration().connectionProvider().release(connection);
+    }
+
+    @Override
     public DSLContext getContext() {
         return context;
     }


### PR DESCRIPTION
* JOOQ opened the connection, it will now also be responsible for closing it
* Resolving bug in CompositionAccess.retrieveCompositionVersion where the connection was being left open